### PR TITLE
Fix matrix rendering problem in PDF files

### DIFF
--- a/Calcpad.Api/PyCalcpad/doc/template.bg.html
+++ b/Calcpad.Api/PyCalcpad/doc/template.bg.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Calcpad.Api/PyCalcpad/doc/template.html
+++ b/Calcpad.Api/PyCalcpad/doc/template.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Calcpad.Cli/doc/template.bg.html
+++ b/Calcpad.Cli/doc/template.bg.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Calcpad.Cli/doc/template.html
+++ b/Calcpad.Cli/doc/template.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Calcpad.Wpf/doc/readme.bg.html
+++ b/Calcpad.Wpf/doc/readme.bg.html
@@ -618,7 +618,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -649,12 +649,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
         .hl {

--- a/Calcpad.Wpf/doc/readme.html
+++ b/Calcpad.Wpf/doc/readme.html
@@ -607,7 +607,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -638,12 +638,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
         .hl {background-color: #FFFAE0;}

--- a/Calcpad.Wpf/doc/readme.zh.html
+++ b/Calcpad.Wpf/doc/readme.zh.html
@@ -607,7 +607,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -638,12 +638,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
         .hl {background-color: #FFFAE0;}

--- a/Calcpad.Wpf/doc/template.bg.html
+++ b/Calcpad.Wpf/doc/template.bg.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Calcpad.Wpf/doc/template.html
+++ b/Calcpad.Wpf/doc/template.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Calcpad.Wpf/doc/template.zh.html
+++ b/Calcpad.Wpf/doc/template.zh.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 

--- a/Translation/Chinese/Html/template.zh.html
+++ b/Translation/Chinese/Html/template.zh.html
@@ -149,7 +149,7 @@
                 }
 
         .matrix {
-            display: inine-table;
+            display: inline-table;
         }
 
             .matrix .tr {
@@ -180,12 +180,12 @@
 
             .matrix .tr:first-child .td:first-child,
             .matrix .tr:first-child .td:last-child {
-                border-top: solid 0.5pt black;
+                border-top: solid 1pt black;
             }
 
             .matrix .tr:last-child .td:first-child,
             .matrix .tr:last-child .td:last-child {
-                border-bottom: solid 0.5pt black;
+                border-bottom: solid 1pt black;
             }
 
 


### PR DESCRIPTION
The matrix rendering problem can be seen in [Continuous beam example](https://github.com/Proektsoftbg/Calcpad/blob/main/Examples/Mechanics/Structural%20Analysis/Continuous%20beam/Continuous%20beam.pdf), as shown below:

![image](https://github.com/user-attachments/assets/493644a4-e4f0-4e3d-a192-2d13f2e78f3a)
