### PR TITLE
Make deb package installable using su as well as sudo

### DIFF
--- a/Calcpad.Cli/Calcpad.Cli.csproj
+++ b/Calcpad.Cli/Calcpad.Cli.csproj
@@ -202,16 +202,15 @@
   <PropertyGroup>
     <PostInstallScript>
       <![CDATA[
-      mkdir -p "/home/$SUDO_USER/calcpad" \
-      && cp -a "/usr/share/Calcpad/Examples" "/home/$SUDO_USER/calcpad/Examples" \
-      && mkdir -p "/home/$SUDO_USER/calcpad/syntax/Sublime" \
-      && cp -a "/usr/share/Calcpad/Syntax/Sublime" "/home/$SUDO_USER/calcpad/syntax" \
-      && mkdir -p "/home/$SUDO_USER/.config/calcpad/" \
-      && cp "/usr/share/Calcpad/Settings.xml" "/home/$SUDO_USER/.config/calcpad/Settings.xml" \
-      && cp -a "/usr/share/Calcpad/Fonts" "/usr/share/fonts/opentype" \
-      && chown -R $SUDO_USER "/home/$SUDO_USER/calcpad" "/home/$SUDO_USER/.config/calcpad/" \
-      && rm -rf "/usr/share/Calcpad/Examples"
+      cd /usr/share/fonts/opentype && ln -s "../../Calcpad/Fonts" "calcpad"
       ]]>
     </PostInstallScript>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PreRemoveScript>
+      <![CDATA[
+      rm /usr/share/fonts/opentype/calcpad
+      ]]>
+    </PreRemoveScript>
   </PropertyGroup>
 </Project>

--- a/Calcpad.Cli/start.sh
+++ b/Calcpad.Cli/start.sh
@@ -1,2 +1,22 @@
 ﻿#!/bin/sh
-dotnet /usr/share/Calcpad/Calcpad.dll $1 $2 $3
+
+# If the calcpad directory does not exist in this user's home, then we populate it
+if [ ! -e "$HOME/calcpad" ]; then
+    mkdir "$HOME/calcpad"
+    cp -a "/usr/share/Calcpad/Examples" "$HOME/calcpad/Examples"
+    mkdir -p "$HOME/calcpad/syntax/Sublime"
+    cp -a "/usr/share/Calcpad/Syntax/Sublime" "$HOME/calcpad/syntax/Sublime"
+fi
+
+# If the Calcpad configuration directory does not exist yet, then we create it
+if [ ! -e "$HOME/.config/calcpad" ]; then
+    mkdir -p "$HOME/.config/calcpad/"
+fi
+
+# If the Calcpad configuration file itself does not exist yet, we create it
+if [ ! -e "$HOME/.config/calcpad/Settings.xml" ]; then
+    cp "/usr/share/Calcpad/Settings.xml" "$HOME/.config/calcpad/Settings.xml"
+fi
+
+# Exec into the actual executable, passing all arguments
+exec dotnet /usr/share/Calcpad/Calcpad.dll "$@"


### PR DESCRIPTION
All user-related file installations are now done on first invocation by the /usr/bin/calcpad script; the postinst script only sets up a font symlink (and a new prerm script removes this symlink on package uninstall).

This removes references to SUDO_USER and thus makes the package installable using su as well as sudo. Also, this makes calcpad usable by all users on the system, and each user gets their own copy of the settings, examples, docs etc.